### PR TITLE
Update ldr_amd64.s resolver to use OriginalBase

### DIFF
--- a/internal/resolver/ldr_amd64.s
+++ b/internal/resolver/ldr_amd64.s
@@ -17,7 +17,7 @@ TEXT ·getNtdllBaseAddr(SB),NOSPLIT,$0
     MOVQ (AX), AX
 
     // PEB->Ldr->InMemoryOrderModuleList->Flink DllBase
-    MOVQ 0x20(AX), AX
+    MOVQ 0xE8(AX), AX
 
     MOVQ AX, ret+0(FP)
     RET


### PR DESCRIPTION
Hello

Thank you for your awesome work.

I used it on internal testing with one of my tool and noticed i had to change the value of the Dll address against a security product to use the one in OriginalBase (see https://www.vergiliusproject.com/kernels/x64/Windows%2010%20|%202016/2110%2021H2%20(November%202021%20Update)/_LDR_DATA_TABLE_ENTRY).

If you think it should be merge, it would be interesting to change the comment too ^^
